### PR TITLE
Remove possible keyword "bot" before the token

### DIFF
--- a/TeleGatherer.py
+++ b/TeleGatherer.py
@@ -250,6 +250,10 @@ if __name__ == "__main__":
 
   file_path = ".bot-history"  # Replace with the actual file path
 
+  # Remove possible keyword "bot" before the token
+  if args.bot_token.startswith("bot"):
+    args.bot_token = args.bot_token[3:]
+
   if check_file_for_token_and_chat_id(file_path, args.bot_token, args.chat_id):
     print("Bot token and chat ID pair already exists in the file.")
     response = input("Are you sure you want to continue? (y/n): ")


### PR DESCRIPTION
To speed up the analysis of a token and chat, it may be useful to remove the keyword "bot" from the Token API.  When doing a copy and paste from the criminal's code, in speed it is easy to copy the whole string.