### PR TITLE
Code cleanup and feature request implementation

### DIFF
--- a/.bot-history
+++ b/.bot-history
@@ -1,0 +1,1 @@
+None:None

--- a/TeleGatherer.py
+++ b/TeleGatherer.py
@@ -140,21 +140,23 @@ def main(bot_token, chat_id):
   can_read = get_bot_info(bot_token).get('result',
                                          {}).get('can_read_all_group_messages',
                                                  False)
-  print(parse_dict("Bot Information", get_bot_info(bot_token)))
-  print(parse_dict("Chat Information", get_chat_info(bot_token, chat_id)))
-  print(
-      parse_dict("Chat Administrators",
-                 get_chat_administrators(bot_token, chat_id)))
-  print(
-      parse_dict("My Default Administrator Rights",
-                 get_My_Default_AdministratorRights(bot_token, chat_id)))
-  print(
-      parse_dict("Available Bot Commands", get_my_commands(chat_id,
-                                                           bot_token)))
-  print(
-      parse_dict("Chat Member Count",
-                 get_chat_member_count(bot_token, chat_id)))
-
+  if not args.silent:
+    print(parse_dict("Bot Information", get_bot_info(bot_token)))
+    print(parse_dict("Chat Information", get_chat_info(bot_token, chat_id)))
+    print(
+        parse_dict("Chat Administrators",
+                  get_chat_administrators(bot_token, chat_id)))
+    print(
+        parse_dict("My Default Administrator Rights",
+                  get_My_Default_AdministratorRights(bot_token, chat_id)))
+    print(
+        parse_dict("Available Bot Commands", get_my_commands(chat_id,
+                                                            bot_token)))
+    print(
+        parse_dict("Chat Member Count",
+                  get_chat_member_count(bot_token, chat_id)))
+  if args.info:
+    exit()
   while True:
     print("\nOptions:")
     print("1. Monitor for new messages from a different bot")
@@ -280,7 +282,9 @@ def add_token_and_chat_id_to_file(file_path, bot_token, chat_id):
 if __name__ == "__main__":
   parser = argparse.ArgumentParser(description="Telegram Bot Script")
   parser.add_argument("-t", "--bot_token", help="Telegram Bot Token")
+  parser.add_argument("-i", "--info", help="Get Bot Information and exit", action="store_true")
   parser.add_argument("-c", "--chat_id", help="Telegram Chat ID", type=int)
+  parser.add_argument("-s", "--silent", help="Silent mode, no prompts, just show the information and exit", action="store_true")
   args = parser.parse_args()
 
   file_path = ".bot-history"  # Replace with the actual file path

--- a/TeleGatherer.py
+++ b/TeleGatherer.py
@@ -265,14 +265,7 @@ def main(bot_token, chat_id):
     else:
       print("Invalid choice. Please try again.")
 
-
-if __name__ == "__main__":
-  parser = argparse.ArgumentParser(description="Telegram Bot Script")
-  parser.add_argument("-t", "--bot_token", help="Telegram Bot Token")
-  parser.add_argument("-c", "--chat_id", help="Telegram Chat ID", type=int)
-  args = parser.parse_args()
-
-  # Check a file for the bot token and chat id pair it is stored in the file in the form of bot_token:chat_id, then print a message asking if you are sure you want to continue. Otherwise continue and add the bot token and chat id to the file in the form of bot_token:chat_id and continue.
+# Check a file for the bot token and chat id pair it is stored in the file in the form of bot_token:chat_id, then print a message asking if you are sure you want to continue. Otherwise continue and add the bot token and chat id to the file in the form of bot_token:chat_id and continue.
 def check_file_for_token_and_chat_id(file_path, bot_token, chat_id):
   with open(file_path, 'r') as file:
     for line in file:

--- a/helpers/TeleViewer.py
+++ b/helpers/TeleViewer.py
@@ -49,7 +49,11 @@ def parse_and_print_message(message):
 
 
 def process_messages(bot_token, chat_id, num_messages, message_id):
+  directory = f'sessions/{chat_id}'
+  if not os.path.exists(directory):
+    os.makedirs(directory)
   bot_token_filename = bot_token.replace(":", "_").replace("/", "_")
+  bot_token_filename = f"{directory}/{bot_token_filename}.session"
   app = pyrogram.Client(bot_token_filename, api_id, api_hash)
 
   async def main(num_messages, message_id):
@@ -91,7 +95,11 @@ def process_messages(bot_token, chat_id, num_messages, message_id):
               )
             # save to file
             if messages.from_user is not None:
-              with open(f'{messages.from_user.username}_bot.txt', 'a') as file:
+              username = messages.from_user.username
+              directory = f'Downloads/{username}/logs'
+              if not os.path.exists(directory):
+                os.makedirs(directory)
+              with open(f'{directory}/{username}_bot.txt', 'a') as file:
                 file.write(f"Message ID: {messages.id}\n")
                 file.write(
                     f"From User ID: {messages.from_user.id} - Username: {messages.from_user.username}\n"
@@ -100,17 +108,18 @@ def process_messages(bot_token, chat_id, num_messages, message_id):
                 file.write(f"Text: {messages.text}\n")
                 file.write(f"Reply_markup: {messages.reply_markup}\n\n")
               # Save the whole message to a file
-              with open(f'{messages.from_user.username}_bot.json',
+              with open(f'{directory}/{username}_bot.json',
                         'a') as file:
                 file.write(str(messages))
             else:
-              with open(f'{chat_id}_bot.txt', 'a') as file:
+              directory = f'Downloads/{chat_id}/logs'
+              with open(f'{directory}/{chat_id}_bot.txt', 'a') as file:
                 file.write(f"Message ID: {messages.id}\n")
                 file.write(f"Date: {messages.date}\n")
                 file.write(f"Text: {messages.text}\n")
                 file.write(f"Reply_markup: {messages.reply_markup}\n\n")
               # Save the whole message to a file
-              with open(f'{chat_id}_bot.json', 'a') as file:
+              with open(f'{directory}/{chat_id}_bot.json', 'a') as file:
                 file.write(str(messages))
     except AttributeError as e:
       print(f"Error: {e}")


### PR DESCRIPTION
This pull request fixes the issue of duplicate lines of code as described in #7.

It also includes a couple of new features:

1. Added --info and --silent flags. If info flag is included upon TeleGatherer script execution, it will just print the bot information and then exit as suggested in #9. The silent flag will go straight to the action menu, skipping the bot information.

2. Housekeeping as suggested in #5. Now all JSON and TXT logs will can be found under Downloads folder and the sub-directory related to the bot username or chat_id. There is also a new `sessions` directory that includes all the sessions for each bot channel you are connecting to.